### PR TITLE
feat: Enable Shared Drive support for list and search

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -124,6 +124,9 @@ server.resource(
         q: "mimeType='application/vnd.google-apps.document'",
         fields: "files(id, name, createdTime, modifiedTime)",
         pageSize: 50,
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
+        corpora: 'allDrives',
       });
 
       const files = response.data.files || [];
@@ -404,6 +407,9 @@ server.tool(
         q: `mimeType='application/vnd.google-apps.document' and fullText contains '${query}'`,
         fields: "files(id, name, createdTime, modifiedTime)",
         pageSize: 10,
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
+        corpora: 'allDrives',
       });
       
       // Add response logging for debugging


### PR DESCRIPTION
Modified `list-docs` resource and `search-docs` tool to include parameters for Shared Drive access.

The following changes were made to `src/server.ts`:
- Added `supportsAllDrives: true`, `includeItemsFromAllDrives: true`, and `corpora: 'allDrives'` to the `driveClient.files.list` call in the `list-docs` resource.
- Added `supportsAllDrives: true`, `includeItemsFromAllDrives: true`, and `corpora: 'allDrives'` to the `driveClient.files.list` call in the `search-docs` tool.

This allows me to list and search for Google Docs in both My Drive and Shared Drives that you have access to.